### PR TITLE
Add simple daily journal Flask app

### DIFF
--- a/daily_journal_app/README.md
+++ b/daily_journal_app/README.md
@@ -1,0 +1,30 @@
+# Daily Journal App
+
+This is a simple Flask web application to manage daily work and study notes. It allows you to:
+
+- Track tasks with project name, details, progress dates and assignee.
+- Record study logs with references.
+- Keep meetings and memos.
+- View all tasks from a dashboard.
+
+## Setup
+
+1. Create a Python virtual environment (optional).
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Run the application:
+
+```bash
+python app.py
+```
+
+The app will create an `sqlite` database file named `journal.db` in the same directory.
+
+## Deployment
+
+To deploy, push the `daily_journal_app` directory to your GitHub repository and configure a platform like Heroku or Render that supports Flask applications. Ensure that the environment installs the packages from `requirements.txt` before starting `python app.py`.
+

--- a/daily_journal_app/app.py
+++ b/daily_journal_app/app.py
@@ -1,0 +1,75 @@
+from flask import Flask, render_template, request, redirect, url_for
+from datetime import datetime, date
+from models import db, Task, StudyLog, Meeting, Memo
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///journal.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db.init_app(app)
+
+with app.app_context():
+    db.create_all()
+
+@app.route('/')
+def index():
+    today = date.today()
+    tasks = Task.query.filter_by(date=today).all()
+    studies = StudyLog.query.filter_by(date=today).all()
+    meetings = Meeting.query.filter(Meeting.date.like(f"{today}%")).all()
+    memos = Memo.query.filter_by(date=today).all()
+    return render_template('index.html', tasks=tasks, studies=studies, meetings=meetings, memos=memos, today=today)
+
+@app.route('/add_task', methods=['POST'])
+def add_task():
+    t = Task(
+        date=datetime.strptime(request.form['date'], '%Y-%m-%d').date(),
+        project=request.form['project'],
+        details=request.form['details'],
+        start_date=datetime.strptime(request.form['start_date'], '%Y-%m-%d').date() if request.form['start_date'] else None,
+        end_date=datetime.strptime(request.form['end_date'], '%Y-%m-%d').date() if request.form['end_date'] else None,
+        assignee=request.form['assignee']
+    )
+    db.session.add(t)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/add_study', methods=['POST'])
+def add_study():
+    s = StudyLog(
+        date=datetime.strptime(request.form['date'], '%Y-%m-%d').date(),
+        title=request.form['title'],
+        reference=request.form.get('reference'),
+        content=request.form['content']
+    )
+    db.session.add(s)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/add_meeting', methods=['POST'])
+def add_meeting():
+    m = Meeting(
+        date=datetime.strptime(request.form['datetime'], '%Y-%m-%dT%H:%M'),
+        description=request.form['description']
+    )
+    db.session.add(m)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/add_memo', methods=['POST'])
+def add_memo():
+    memo = Memo(
+        date=datetime.strptime(request.form['date'], '%Y-%m-%d').date(),
+        content=request.form['content']
+    )
+    db.session.add(memo)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/dashboard')
+def dashboard():
+    tasks = Task.query.order_by(Task.date.desc()).all()
+    return render_template('dashboard.html', tasks=tasks)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/daily_journal_app/models.py
+++ b/daily_journal_app/models.py
@@ -1,0 +1,35 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+class Task(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date, nullable=False)
+    project = db.Column(db.String(100), nullable=False)
+    details = db.Column(db.Text, nullable=False)
+    start_date = db.Column(db.Date, nullable=True)
+    end_date = db.Column(db.Date, nullable=True)
+    assignee = db.Column(db.String(50), nullable=True)
+
+    def __repr__(self):
+        return f"<Task {self.project} {self.date}>"
+
+class StudyLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date, nullable=False)
+    title = db.Column(db.String(100), nullable=False)
+    reference = db.Column(db.String(200), nullable=True)
+    content = db.Column(db.Text, nullable=False)
+
+    def __repr__(self):
+        return f"<StudyLog {self.title} {self.date}>"
+
+class Meeting(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.DateTime, nullable=False)
+    description = db.Column(db.String(200), nullable=False)
+
+class Memo(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date, nullable=False)
+    content = db.Column(db.Text, nullable=False)

--- a/daily_journal_app/requirements.txt
+++ b/daily_journal_app/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.3.2
+Flask-SQLAlchemy==3.1.1

--- a/daily_journal_app/templates/dashboard.html
+++ b/daily_journal_app/templates/dashboard.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dashboard</title>
+</head>
+<body>
+    <h1>All Tasks</h1>
+    <table border="1">
+        <tr>
+            <th>Date</th>
+            <th>Project</th>
+            <th>Details</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Assignee</th>
+        </tr>
+        {% for t in tasks %}
+        <tr>
+            <td>{{ t.date }}</td>
+            <td>{{ t.project }}</td>
+            <td>{{ t.details }}</td>
+            <td>{{ t.start_date }}</td>
+            <td>{{ t.end_date }}</td>
+            <td>{{ t.assignee }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <a href="/">Back to home</a>
+</body>
+</html>

--- a/daily_journal_app/templates/index.html
+++ b/daily_journal_app/templates/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Daily Journal</title>
+</head>
+<body>
+    <h1>Daily Journal for {{ today }}</h1>
+
+    <h2>Add Task</h2>
+    <form action="/add_task" method="post">
+        Date: <input type="date" name="date" value="{{ today }}"><br>
+        Project: <input type="text" name="project"><br>
+        Details: <textarea name="details"></textarea><br>
+        Start Date: <input type="date" name="start_date"><br>
+        End Date: <input type="date" name="end_date"><br>
+        Assignee: <input type="text" name="assignee"><br>
+        <button type="submit">Add Task</button>
+    </form>
+
+    <h2>Add Study Log</h2>
+    <form action="/add_study" method="post">
+        Date: <input type="date" name="date" value="{{ today }}"><br>
+        Title: <input type="text" name="title"><br>
+        Reference: <input type="text" name="reference"><br>
+        Content: <textarea name="content"></textarea><br>
+        <button type="submit">Add Study Log</button>
+    </form>
+
+    <h2>Add Meeting</h2>
+    <form action="/add_meeting" method="post">
+        Date and time: <input type="datetime-local" name="datetime"><br>
+        Description: <input type="text" name="description"><br>
+        <button type="submit">Add Meeting</button>
+    </form>
+
+    <h2>Add Memo</h2>
+    <form action="/add_memo" method="post">
+        Date: <input type="date" name="date" value="{{ today }}"><br>
+        Content: <textarea name="content"></textarea><br>
+        <button type="submit">Add Memo</button>
+    </form>
+
+    <h2>Today's Tasks</h2>
+    <ul>
+    {% for t in tasks %}
+        <li>{{ t.project }} - {{ t.details }} ({{ t.start_date }} ~ {{ t.end_date }}) - {{ t.assignee }}</li>
+    {% endfor %}
+    </ul>
+
+    <h2>Today's Study Logs</h2>
+    <ul>
+    {% for s in studies %}
+        <li>{{ s.title }} - {{ s.reference }} - {{ s.content }}</li>
+    {% endfor %}
+    </ul>
+
+    <h2>Today's Meetings</h2>
+    <ul>
+    {% for m in meetings %}
+        <li>{{ m.date }} - {{ m.description }}</li>
+    {% endfor %}
+    </ul>
+
+    <h2>Memos</h2>
+    <ul>
+    {% for m in memos %}
+        <li>{{ m.content }}</li>
+    {% endfor %}
+    </ul>
+
+    <a href="/dashboard">Go to dashboard</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `daily_journal_app` Flask application
- implement models for tasks, study logs, meetings, and memos
- add HTML templates for home page and dashboard
- include setup instructions
- list required packages

## Testing
- `python -m py_compile app.py models.py`
- `pip install -r requirements.txt`
- `python app.py` *(ran briefly, started Flask dev server)*

------
https://chatgpt.com/codex/tasks/task_e_686215ce6abc832c870d16793f2b1099